### PR TITLE
Remove redundant .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,12 +78,6 @@ artifacts/
 *.svclog
 *.scc
 
-# OS generated files #
-.DS_Store*
-
-# Mac desktop service store files
-.DS_Store
-
 # Chutzpah Test files
 _Chutzpah*
 


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Remove redundant .DS_Store in .gitignore

