### PR TITLE
issue #81, #85 Provisioning key vault secrets for graph app and storage connection string

### DIFF
--- a/infra/webapp/main-kv.tf
+++ b/infra/webapp/main-kv.tf
@@ -180,3 +180,54 @@ resource "azurerm_key_vault_secret" "trackingupdatequeue" {
   value        = var.TRACKING_QUEUE_NAME
   key_vault_id = azurerm_key_vault.kv.id
 }
+
+resource "azurerm_key_vault_secret" "graphdppclientid" {
+  
+  depends_on = [
+    azurerm_key_vault_access_policy.terraform-sp
+  ]
+
+  name         = "graphdAppClientId"
+  value        = azuread_application.graphclient.application_id
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
+resource "random_password" "graphspsecret" {
+  length = 35
+  special = true
+  override_special = "~!@#$%&*()-_=+[]{}<>:?"
+}
+
+
+resource "azurerm_key_vault_secret" "graphdappclientsecret" {
+  
+  depends_on = [
+    azurerm_key_vault_access_policy.terraform-sp
+  ]
+
+  name         = "graphdAppClientSecret"
+  value        = random_password.graphspsecret.result
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
+resource "azurerm_key_vault_secret" "graphdapptenantid" {
+  
+  depends_on = [
+    azurerm_key_vault_access_policy.terraform-sp
+  ]
+
+  name         = "graphdAppTenantid"
+  value        = var.TENANT_ID
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
+resource "azurerm_key_vault_secret" "storageconnectionstring" {
+  
+  depends_on = [
+    azurerm_key_vault_access_policy.terraform-sp
+  ]
+
+  name         = "SPStorageConnectionString"
+  value        = azurerm_storage_account.svc-ppl-storage-acc.primary_connection_string
+  key_vault_id = azurerm_key_vault.kv.id
+}

--- a/infra/webapp/main-sp.tf
+++ b/infra/webapp/main-sp.tf
@@ -1,0 +1,19 @@
+# Create an application
+resource "azuread_application" "graphclient" {
+    name = "${var.PROJECT_NAME}-graph-${var.ENV}"
+}
+
+# Create a service principal
+resource "azuread_service_principal" "graphsp" {
+  application_id = azuread_application.graphclient.application_id
+
+}
+
+resource "azuread_application_password" "graphsppwd" {
+  depends_on = [azurerm_key_vault_secret.graphdappclientsecret]
+  application_object_id = azuread_application.graphclient.id
+  description           = "appGraphSecret"
+  value                 =  azurerm_key_vault_secret.graphdappclientsecret.value
+  end_date              = "2099-01-01T01:02:03Z"
+}
+


### PR DESCRIPTION
Provisioning key vault secrets for graph app and storage connection string

## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Update terraform scripts to provision  key vault secrets for graph app registration and storage connection string

## Review notes

## Issues Closed or Referenced

- Closes #81 , #85 

Predecessor #28 
