### PR TITLE
Added --pull to make sure docker gets the latest images. Its  redundant for…

### DIFF
--- a/.github/workflows/dockerCI.yml
+++ b/.github/workflows/dockerCI.yml
@@ -57,7 +57,7 @@ jobs:
       if: ${{ env.ACR_LOGGED_IN == 'true' }}
       run: |
         # Build Image
-        docker build -t ${TEMP_IMG_NAME} -f src/Automation/CSE.Automation/Dockerfile src/Automation
+        docker build --pull -t ${TEMP_IMG_NAME} -f src/Automation/CSE.Automation/Dockerfile src/Automation
         # Set variable is successful
         [[ $? == 0 ]] && echo "::set-env name=DKR_IMG_IS_BUILT::true"
 


### PR DESCRIPTION
Using `--pull` arg to `docker build` to make sure docker always pulls the latest images when building images.
Even though Github action creates a fresh VM, adhering to docker best practice is always a good idea.

## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [X] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Adding always pull argument to docker build

## Issues Closed or Referenced

- Closes #104 
- References #104 
