### PR TITLE
Suppressed warning about making class members protected, because we w…

### DIFF
--- a/src/Automation/CSE.Automation/GlobalSuppressions.cs
+++ b/src/Automation/CSE.Automation/GlobalSuppressions.cs
@@ -5,4 +5,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "<Pending>", Scope = "member", Target = "~P:CSE.Automation.Model.ProcessorConfiguration.SelectFields")]
+[assembly: SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Fields needed to be accessed by derived classes.", Scope = "member", Target = "CSE.Automation.Processors.DeltaProcessorBase._uniqueId")]
+[assembly: SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Fields needed to be accessed by derived classes.", Scope = "member", Target = "~F:CSE.Automation.Processors.DeltaProcessorBase._configDAL")]
+[assembly: SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "Fields needed to be accessed by derived classes.", Scope = "member", Target = "~F:CSE.Automation.Processors.DeltaProcessorBase._config")]
+

--- a/src/Automation/CSE.Automation/GraphDeltaProcessor.cs
+++ b/src/Automation/CSE.Automation/GraphDeltaProcessor.cs
@@ -65,6 +65,10 @@ namespace CSE.Automation
             [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
             ILogger log)
         {
+            // TODO: If we end up with now request params needed for the seed function then remove the param and this check.
+            if (req is null)
+                throw new ArgumentNullException(nameof(req));
+
             var queueConnectionString = _secretService.GetSecretValue(Constants.SPStorageConnectionString);
             var dataQueueName = _secretService.GetSecretValue(Constants.SPTrackingUpdateQueue);
             ProcessorConfiguration config = null; //TODO

--- a/src/Automation/CSE.Automation/Model/AuditEntry.cs
+++ b/src/Automation/CSE.Automation/Model/AuditEntry.cs
@@ -17,6 +17,9 @@ namespace CSE.Automation.Model
 
         public AuditEntry(IGraphModel originalDocument)
         {
+            if (originalDocument is null)
+                throw new ArgumentNullException(nameof(originalDocument));
+
             this.Id = originalDocument.Id;
             this.Created = originalDocument.Created;
             this.Deleted = originalDocument.Deleted;

--- a/src/Automation/CSE.Automation/Model/Notes.cs
+++ b/src/Automation/CSE.Automation/Model/Notes.cs
@@ -1,8 +1,11 @@
 ﻿
+using Microsoft.Graph;
+using System.Collections.Generic;
+
 namespace CSE.Automation.Model
 {
     public class Notes
     {
-        public string[] BusinessOwners { get; set; }
+        public List<string> BusinessOwners { get; }
     }
 }

--- a/src/Automation/CSE.Automation/Model/ProcessorConfiguration.cs
+++ b/src/Automation/CSE.Automation/Model/ProcessorConfiguration.cs
@@ -15,7 +15,7 @@ namespace CSE.Automation.Model
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public ProcessorType ConfigType { get; set; }
 
-        public List<string> SelectFields { get; set; }
+        public List<string> SelectFields { get;  }
 
         public string DeltaLink { get; set; }
 

--- a/src/Automation/CSE.Automation/Processors/DeltaProcessorBase.cs
+++ b/src/Automation/CSE.Automation/Processors/DeltaProcessorBase.cs
@@ -11,8 +11,8 @@ namespace CSE.Automation.Processors
 {
     public class DeltaProcessorBase : IDeltaProcessor
     {
-        private IDAL _configDAL;
-        private ProcessorConfiguration _config;
+        protected IDAL _configDAL;
+        protected ProcessorConfiguration _config;
         protected string _uniqueId = string.Empty;
         public string ProcessorId
         {

--- a/src/Automation/CSE.Automation/Services/AzureQueueService.cs
+++ b/src/Automation/CSE.Automation/Services/AzureQueueService.cs
@@ -27,6 +27,9 @@ namespace CSE.Automation.Services
 
         public async Task Send(QueueMessage message, int visibilityDelay)
         {
+            if (message is null)
+                throw new ArgumentNullException(nameof(message));
+
             bool messageSent = false;
             int numOfAttempts = 1;
             


### PR DESCRIPTION
…ant access in the derived classes.

Made List<string> fields read-only.  Updates are accomplished through add/remove on the list.

Added null checks

## Type of PR

- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Remediate linter issues.

## Review notes

- Suppressed warning about making class members protected, because we want access in the derived classes.
- Made List<string> fields read-only.  Updates are accomplished through add/remove on the list.
- Added null checks

## Issues Closed or Referenced

- Closes #115

