### PR TITLE
Pull Timer Trigger schedule from configuration

### DIFF
--- a/src/Automation/CSE.Automation/Constants.cs
+++ b/src/Automation/CSE.Automation/Constants.cs
@@ -27,6 +27,9 @@
         public const string EvaluateQueueAppSetting = "%SPEvaluateQueue%";
         public const string SPAADUpdateQueueAppSetting = "%SPAADUpdateQueue%";
 
+        // Azure Timer Function Constants
+        public const string DeltaDiscoverySchedule = "%SPDeltaDiscoverySchedule%";
+
         //Queueing Constants
         public const int MaxVisibilityDelayGapSeconds = 500;
         public const int MaxQueueRecordProcessThreshold = 3000;

--- a/src/Automation/CSE.Automation/GraphDeltaProcessor.cs
+++ b/src/Automation/CSE.Automation/GraphDeltaProcessor.cs
@@ -34,7 +34,7 @@ namespace CSE.Automation
         [FunctionName("DiscoverDeltas")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Will add specific error in time.")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1801:Review unused parameters", Justification = "Required as part of Trigger declaration.")]
-        public async Task Deltas([TimerTrigger("0 */30 * * * *")] TimerInfo myTimer, ILogger log)
+        public async Task Deltas([TimerTrigger(Constants.DeltaDiscoverySchedule)] TimerInfo myTimer, ILogger log)
         {
             var context = new ActivityContext();
             log.LogDebug("Executing SeedDeltaProcessorTimer Function");


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Pull the configuration of the DeltaDiscovery timer schedule from configuration.

## Review notes

## Issues Closed or Referenced

- Closes #50 
- References #<issue number> (this references the issue but does not close with PR)
