### PR TITLE
Only Push Docker Image on Merge

### DIFF
--- a/.github/workflows/dockerCI.yml
+++ b/.github/workflows/dockerCI.yml
@@ -71,7 +71,7 @@ jobs:
         docker build --pull -t ${TEMP_IMG_NAME} \
                     --build-arg SP_AUTOMATION_VERSION=${FULL_VER_STRING} \
                     --build-arg SP_AUTOMATION_GITHASH=${GIT_HASH} \
-                    --label "githash"="${GIT_HASH}"
+                    --label "githash"="${GIT_HASH}" \
                     -f src/Automation/CSE.Automation/Dockerfile src/Automation
         # Set variable is successful
         [[ $? == 0 ]] && echo "::set-env name=DKR_IMG_IS_BUILT::true"


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Pull ACR Name from docker CI script rather than github secrets as it is not a secret and for better developer visibility.
Only push image after a merge into main
Align docker image name with terraform scripts
Use PR Number for image version rather than githash and add githash as an image label

## Review notes

## Issues Closed or Referenced

- Closes #220 