### PR TITLE
Fix for "AzQueueTool is unable to push messages when targeting Azure storage instead local storage emulator"

### DIFF
--- a/spikes/AzQueueTestTool/AzQueueTestTool/TestCases/Queues/QueueServiceManager.cs
+++ b/spikes/AzQueueTestTool/AzQueueTestTool/TestCases/Queues/QueueServiceManager.cs
@@ -62,7 +62,7 @@ namespace AzQueueTestTool.TestCases.Queues
                         Attempt = 0
                     };
 
-                    Task queueTask = Task.Run(() => _azureQueueService.Send(myMessage, 3).ConfigureAwait(false));
+                    Task queueTask = Task.Run(() => _azureQueueService.Send(myMessage, 3));
 
                     queueTasks.Add(queueTask);
 


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Fix for "AzQueueTool is unable to push messages when targeting Azure storage instead local storage emulator"
## Review notes

## Issues Closed or Referenced

- Closes #276 
- References #247 
