### PR TITLE
Disable GitHub Action on PR Close

### DIFF
--- a/.github/workflows/dockerCI.yml
+++ b/.github/workflows/dockerCI.yml
@@ -14,7 +14,7 @@ on:
       - v*
   
   pull_request:
-    types: [ opened, reopened, synchronize, closed ]
+    types: [ opened, reopened, synchronize ]
     branches:
       - main
 


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Disabling unnecessary GitHub action on PR close event.

Currently actions are performed when:
- pushing to a PR branch (builds PR branch and updates image:<PR_NUMBER> in ACT
- pushing to main (occurs after a close event and builds main branch and pushes to image:latest)
- closing a PR (builds the PR branch and a duplicate of pushing to PR branch)

## Review notes

## Issues Closed or Referenced

- Closes #292 
