### PR TITLE
Spike: Add Domain Owner To Third Party SP Classification

### DIFF
--- a/spikes/ServicePrincipalClassification/Classification.ps1
+++ b/spikes/ServicePrincipalClassification/Classification.ps1
@@ -34,6 +34,7 @@ function ClassifyMicrosoft
       else {
         $_.Tags += "Addition"
       }
+      $_.Tags += ""
     }
 }
 
@@ -47,6 +48,7 @@ function ClassifyTenant
     ForEach-Object {
       $_.Tags += "Tenant"
       $_.Tags += $_.ServicePrincipalType
+      $_.Tags += ""
     }
 }
 
@@ -60,6 +62,11 @@ function ClassifyThirdParty
     ForEach-Object {
       $_.Tags += "ThirdParty"
       $_.Tags += $_.ServicePrincipalType
+      $_.Tags += (($_.ServicePrincipalNames.split(", ") |
+                   ForEach-Object {[System.Uri]$_} |
+                   Where-Object {$null -ne $_.Host} |
+                   ForEach-Object {$_.Host} |
+                   Get-Unique ) -join ", ")
     }
 }
 
@@ -111,7 +118,7 @@ $groups |
   }
 
   $results = $spList |
-      Select-Object -Property @{N='Classification';E={$_.Tags[-2]}}, @{N='Category';E={$_.Tags[-1]}}, Id, AppOwnerOrganizationId, AppId, DisplayName, @{N='ServicePrincipalNames';E={$_.ServicePrincipalNames -join ", "}}, ServicePrincipalType
+      Select-Object -Property @{N='Classification';E={$_.Tags[-3]}}, @{N='Category';E={$_.Tags[-2]}}, @{N='OwningDomain';E={$_.Tags[-1]}}, Id, AppOwnerOrganizationId, AppId, DisplayName, @{N='ServicePrincipalNames';E={$_.ServicePrincipalNames -join ", "}}, ServicePrincipalType
 
   Write-Host "Summary of Results:"
       $results | Group-Object -Property Classification, Category | Sort-Object Count -D | Select-Object -Property Count, @{N='Classification';E={$_.Group[0].Classification}}, @{N='Category';E={$_.Group[0].Category}} | Out-String | Write-Host


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Update Classification Script to output owning domain for third parties.

![image](https://user-images.githubusercontent.com/52010147/101401461-04b3aa80-3898-11eb-8f1b-a7e93250f703.png)

## Review notes

## Issues Closed or Referenced

- References #299
