### PR TITLE
Added AppId to AuditEntry, AuditCode serialized as string

### DIFF
--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/GraphDeltaProcessorFunctionsTests.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/GraphDeltaProcessorFunctionsTests.cs
@@ -20,7 +20,6 @@ using CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.ServicePrincipa
 using CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators;
 using static CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.TestCases.TestCaseCollection;
 using System.Runtime.CompilerServices;
-using CSE.Automation.Validators;
 using CSE.Automation.KeyVault;
 using CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.DataAccess;
 using System.Reflection;
@@ -29,6 +28,7 @@ using CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.ConfigurationRe
 using CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.ActivityResults;
 using CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.Helpers;
 using System.IO;
+using CSE.Automation.Model.Validators;
 
 namespace CSE.Automation.Tests.FunctionsUnitTests
 {

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/ActivityResuts/ActivityValidationManager.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/ActivityResuts/ActivityValidationManager.cs
@@ -45,7 +45,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.ActivityRes
             }
             else
             {
-                throw new Exception($"Unable to get ActivityHistory record for Test Case Id: {_inputGenerator.TestCaseId}");
+                throw new Exception($"Unable to get ActivityHistory record for Test Case ObjectId: {_inputGenerator.TestCaseId}");
             }
 
             return result;

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator1.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator1.cs
@@ -23,13 +23,13 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
 
             bool typePass = (NewAuditEntry.Type == AuditActionType.Pass);
             
-            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Pass_ServicePrincipal.Description());
+            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Pass.Description());
 
             //SavedAuditEntry will be null when Audit Colection is empty
             bool isNewAuditEntryPass = SavedAuditEntry != null ? NewAuditEntry.Timestamp > SavedAuditEntry.Timestamp : true;
             
-            bool validCorrelationIdPass = Guid.TryParse(NewAuditEntry.CorrelationId, out Guid dummyGuid) &&
-                                        NewAuditEntry.CorrelationId.Equals(Context.CorrelationId);
+            bool validCorrelationIdPass = NewAuditEntry.Descriptor != null && Guid.TryParse(NewAuditEntry.Descriptor.CorrelationId, out Guid dummyGuid) &&
+                                        NewAuditEntry.Descriptor.CorrelationId.Equals(Context.CorrelationId);
 
             return (typePass && isNewAuditEntryPass && validCorrelationIdPass && validReasonPass);
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator2.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator2.cs
@@ -23,13 +23,13 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
             bool typePass = (NewAuditEntry.Type == AuditActionType.Pass);
 
 
-            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Pass_ServicePrincipal.Description());
+            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Pass.Description());
 
             //SavedAuditEntry will be null when Audit Colection is empty
             bool isNewAuditEntryPass = SavedAuditEntry != null ? NewAuditEntry.Timestamp > SavedAuditEntry.Timestamp : true;
             
-            bool validCorrelationIdPass = Guid.TryParse(NewAuditEntry.CorrelationId, out Guid dummyGuid) &&
-                                        NewAuditEntry.CorrelationId.Equals(Context.CorrelationId);
+            bool validCorrelationIdPass = NewAuditEntry.Descriptor != null && Guid.TryParse(NewAuditEntry.Descriptor.CorrelationId, out Guid dummyGuid) &&
+                                          NewAuditEntry.Descriptor.CorrelationId.Equals(Context.CorrelationId);
 
             return (typePass && isNewAuditEntryPass && validCorrelationIdPass && validReasonPass );
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator2_2.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator2_2.cs
@@ -23,13 +23,13 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
             bool typePass = (NewAuditEntry.Type == AuditActionType.Pass);
 
 
-            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Pass_ServicePrincipal.Description());
+            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Pass.Description());
 
             //SavedAuditEntry will be null when Audit Colection is empty
             bool isNewAuditEntryPass = SavedAuditEntry != null ? NewAuditEntry.Timestamp > SavedAuditEntry.Timestamp : true;
             
-            bool validCorrelationIdPass = Guid.TryParse(NewAuditEntry.CorrelationId, out Guid dummyGuid) &&
-                                        NewAuditEntry.CorrelationId.Equals(Context.CorrelationId);
+            bool validCorrelationIdPass = NewAuditEntry.Descriptor != null && Guid.TryParse(NewAuditEntry.Descriptor.CorrelationId, out Guid dummyGuid) &&
+                                          NewAuditEntry.Descriptor.CorrelationId.Equals(Context.CorrelationId);
 
             return (typePass && isNewAuditEntryPass && validCorrelationIdPass && validReasonPass );
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator3.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator3.cs
@@ -37,7 +37,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
             {
                 bool typePass = (auditEntry.Type == AuditActionType.Fail);
 
-                bool validReasonPass = (auditEntry.Reason == AuditCode.Fail_AttributeValidation.Description());
+                bool validReasonPass = (auditEntry.Reason == AuditCode.AttributeValidation.Description());
 
                 bool validAttributeNamePass = (auditEntry.AttributeName == "Notes");
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator3_2.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator3_2.cs
@@ -36,7 +36,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
             {
                 bool typePass = (auditEntry.Type == AuditActionType.Fail);
 
-                bool validReasonPass = (auditEntry.Reason == AuditCode.Fail_AttributeValidation.Description());
+                bool validReasonPass = (auditEntry.Reason == AuditCode.AttributeValidation.Description());
 
                 bool validAttributeNamePass = (auditEntry.AttributeName == "Notes");
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator4.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator4.cs
@@ -36,7 +36,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
             {
                 bool typePass = (auditEntry.Type == AuditActionType.Fail);
 
-                bool validReasonPass = (auditEntry.Reason == AuditCode.Fail_AttributeValidation.Description());
+                bool validReasonPass = (auditEntry.Reason == AuditCode.AttributeValidation.Description());
 
                 //SavedAuditEntry will be null when Audit Colection is empty
                 bool isNewAuditEntryPass = SavedAuditEntry != null ? auditEntry.Timestamp > SavedAuditEntry.Timestamp : true;

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator5.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator5.cs
@@ -33,8 +33,8 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
             {
                 bool typePass = (auditEntry.Type == AuditActionType.Fail);
 
-                bool validReasonPass = (auditEntry.Reason == AuditCode.Fail_MissingOwners.Description()) ||
-                                        (auditEntry.Reason == AuditCode.Fail_AttributeValidation.Description());
+                bool validReasonPass = (auditEntry.Reason == AuditCode.MissingOwners.Description()) ||
+                                        (auditEntry.Reason == AuditCode.AttributeValidation.Description());
 
                 bool isNewAuditEntryPass = SavedAuditEntry != null ? auditEntry.Timestamp > SavedAuditEntry.Timestamp : true;
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator6.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/AuditResultValidator6.cs
@@ -34,7 +34,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
             {
                 bool typePass = (auditEntry.Type == AuditActionType.Fail);
 
-                bool validReasonPass = (auditEntry.Reason == AuditCode.Fail_AttributeValidation.Description());
+                bool validReasonPass = (auditEntry.Reason == AuditCode.AttributeValidation.Description());
 
                 bool validAttributeNamePass = (auditEntry.AttributeName == "Notes");
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/Discover/DiscoverAuditResultValidator2.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/Discover/DiscoverAuditResultValidator2.cs
@@ -26,13 +26,13 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
             bool typePass = (NewAuditEntry.Type == AuditActionType.Pass);
 
 
-            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Ignore_ServicePrincipalDeleted.Description());
+            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Deleted.Description());
                                
 
             bool isNewAuditEntryPass = NewAuditEntry.Timestamp > SavedAuditEntry.Timestamp;
             
-            bool validCorrelationIdPass = Guid.TryParse(NewAuditEntry.CorrelationId, out Guid dummyGuid) &&
-                                        NewAuditEntry.CorrelationId.Equals(Context.CorrelationId);
+            bool validCorrelationIdPass = Guid.TryParse(NewAuditEntry.Descriptor.CorrelationId, out Guid dummyGuid) &&
+                                        NewAuditEntry.Descriptor.CorrelationId.Equals(Context.CorrelationId);
 
             return (typePass && isNewAuditEntryPass && validCorrelationIdPass && validReasonPass );
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/Update/UpdateAuditResultValidator.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/AuditResults/Update/UpdateAuditResultValidator.cs
@@ -26,12 +26,12 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.AuditResult
             bool attributeNamePass = NewAuditEntry.AttributeName == "Notes";
 
 
-            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Change_ServicePrincipalUpdated.Description());
+            bool validReasonPass = (NewAuditEntry.Reason == AuditCode.Updated.Description());
 
             bool isNewAuditEntryPass = NewAuditEntry.Timestamp > SavedAuditEntry.Timestamp;
             
-            bool validCorrelationIdPass = Guid.TryParse(NewAuditEntry.CorrelationId, out Guid dummyGuid) &&
-                                        NewAuditEntry.CorrelationId.Equals(Context.CorrelationId);
+            bool validCorrelationIdPass = NewAuditEntry.Descriptor != null && Guid.TryParse(NewAuditEntry.Descriptor.CorrelationId, out Guid dummyGuid) &&
+                                        NewAuditEntry.Descriptor.CorrelationId.Equals(Context.CorrelationId);
 
             return (attributeNamePass && typePass && isNewAuditEntryPass && validCorrelationIdPass && validReasonPass);
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/Extensions.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/Extensions.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using CSE.Automation.Model.Validators;
 using CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.System.ComponentModel;
 using CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.TestCases;
-using CSE.Automation.Validators;
 
 namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators
 {

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/InputGeneratorBase.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/InputGeneratorBase.cs
@@ -147,7 +147,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators
 
                 if (_servicePrincipalWrapper == null)
                 {
-                    throw new Exception($"Unable to create ServicePrincipalWrapper for Test Case Id: {TestCaseId}");
+                    throw new Exception($"Unable to create ServicePrincipalWrapper for Test Case ObjectId: {TestCaseId}");
                 }
             }
             return _servicePrincipalWrapper;

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/ServicePrincipalResults/SpResultValidatorBase.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/ServicePrincipalResults/SpResultValidatorBase.cs
@@ -88,7 +88,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators.ServicePrin
                         {
                             if (!messageFound)/// state.Break(); takes its time and does not break the loop immediately 
                             {
-                                messageFound = command.CorrelationId == _activityContext.CorrelationId && command.Id == NewServicePrincipal.Id
+                                messageFound = command.CorrelationId == _activityContext.CorrelationId && command.ObjectId == NewServicePrincipal.Id
                                               && targetQueueMessages.Contains(command.Action); // we need to use Enums instead of "Strings"
 
 

--- a/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/UpdateInputGenerator.cs
+++ b/src/Automation/CSE.Automation.Tests/FunctionsUnitTests/TestCaseValidators/UpdateInputGenerator.cs
@@ -61,7 +61,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests.TestCaseValidators
             var updateCommand = new ServicePrincipalUpdateCommand()
             {
                 CorrelationId = activityContext.CorrelationId,
-                Id = _validatedServicePrincipalWraper.AADServicePrincipal.Id,
+                ObjectId = _validatedServicePrincipalWraper.AADServicePrincipal.Id,
                 Notes = (_validatedServicePrincipalWraper.AADServicePrincipal.Notes, ownersListAsString),
                 Action = ServicePrincipalUpdateAction.Update, // "Update Notes from Owners",
             };

--- a/src/Automation/CSE.Automation.Tests/ModelValidationUnitTests/ModelValidationTests.cs
+++ b/src/Automation/CSE.Automation.Tests/ModelValidationUnitTests/ModelValidationTests.cs
@@ -3,11 +3,11 @@ using Xunit;
 using CSE.Automation.Model;
 using FluentValidation;
 using System;
-using CSE.Automation.Validators;
 using CSE.Automation.Graph;
 using Microsoft.Graph;
 using System.Threading.Tasks;
 using CSE.Automation.Interfaces;
+using CSE.Automation.Model.Validators;
 using Newtonsoft.Json;
 using Xunit.Abstractions;
 using ActivityContext = CSE.Automation.Model.ActivityContext;
@@ -38,7 +38,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests
         AbstractValidator<AuditEntry> auditEntryValidator = new AuditEntryValidator();
 
         [Fact]
-        [Trait("Category","Unit")]
+        [Trait("Category", "Unit")]
         public void ServicePrincipalModelValidate_ReturnsValidationFailuresIfInvalid()
         {
             var servicePrincipal = new ServicePrincipalModel
@@ -56,7 +56,7 @@ namespace CSE.Automation.Tests.FunctionsUnitTests
         }
 
         [Fact]
-        [Trait("Category","Unit")]
+        [Trait("Category", "Unit")]
         public void ServicePrincipalModelValidate_ReturnsTrueIfValid()
         {
             var servicePrincipal = new ServicePrincipalModel
@@ -74,13 +74,13 @@ namespace CSE.Automation.Tests.FunctionsUnitTests
 
             var results = servicePrincipalValidator.Validate(servicePrincipal);
             output.WriteLine(JsonConvert.SerializeObject(results, Formatting.Indented));
-            
+
             Assert.True(results.IsValid);
             Assert.True(results.Errors.Count == 0);
         }
 
         [Fact]
-        [Trait("Category","Unit")]
+        [Trait("Category", "Unit")]
         public void AuditEntryModelValidate_ReturnsValidationFailuresIfInvalid()
         {
             var auditItem = new AuditEntry();
@@ -89,25 +89,29 @@ namespace CSE.Automation.Tests.FunctionsUnitTests
             output.WriteLine(JsonConvert.SerializeObject(results, Formatting.Indented));
 
             Assert.False(results.IsValid);
-            Assert.Contains(results.Errors, x => x.PropertyName == "CorrelationId");
+            Assert.Contains(results.Errors, x => x.PropertyName == "Descriptor");
             Assert.Contains(results.Errors, x => x.PropertyName == "Type");
             Assert.Contains(results.Errors, x => x.PropertyName == "Reason");
         }
 
         [Fact]
-        [Trait("Category","Unit")]
+        [Trait("Category", "Unit")]
         public void AuditEntryModelValidate_ReturnsTrueIfValid()
         {
             var context = new ActivityContext(null);
 
             var auditItem = new AuditEntry()
             {
-                CorrelationId = "fake correlation id",
+                Descriptor = new AuditDescriptor()
+                {
+                    CorrelationId = "fake correlation id",
+                    ObjectId = "fake object id",
+                },
                 Type = AuditActionType.Change,
                 Reason = "fake action reason",
-                AuditYearMonth = "qweradsf",
-                AttributeName = "asdf",
-                ExistingAttributeValue = "asdf",
+                AuditYearMonth = "202011",
+                AttributeName = "attribute",
+                ExistingAttributeValue = "value",
                 Timestamp = DateTimeOffset.Now
             };
 

--- a/src/Automation/CSE.Automation.TestsPrep/TestCases/StringExtensions.cs
+++ b/src/Automation/CSE.Automation.TestsPrep/TestCases/StringExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
-using CSE.Automation.Validators;
+using CSE.Automation.Model.Validators;
 
 namespace CSE.Automation.TestsPrep.TestCases
 {

--- a/src/Automation/CSE.Automation/DataAccess/CosmosDBRepository.cs
+++ b/src/Automation/CSE.Automation/DataAccess/CosmosDBRepository.cs
@@ -143,7 +143,7 @@ namespace CSE.Automation.DataAccess
         /// <summary>
         /// Given a document id and its partition value, retrieve the document, if it exists.
         /// </summary>
-        /// <param name="id">Id of the document.</param>
+        /// <param name="id">ObjectId of the document.</param>
         /// <param name="partitionKey">Value of the partitionkey for the document.</param>
         /// <returns>An instance of the document or null.</returns>
         public async Task<TEntity> GetByIdAsync(string id, string partitionKey)

--- a/src/Automation/CSE.Automation/Graph/ServicePrincipalGraphHelper.cs
+++ b/src/Automation/CSE.Automation/Graph/ServicePrincipalGraphHelper.cs
@@ -90,7 +90,7 @@ namespace CSE.Automation.Graph
         /// <summary>
         /// Gets Service Principal Graph Object With Owners
         /// </summary>
-        /// <param name="id">The Service Principal Oject Id</param>
+        /// <param name="id">The Service Principal Oject ObjectId</param>
         /// <returns>Tasks with Service Principal </returns>
         public async override Task<ServicePrincipal> GetGraphObjectWithOwners(string id)
         {
@@ -145,9 +145,14 @@ namespace CSE.Automation.Graph
 
                 // Report Audit Ignore messages for all the elements that were already removed from the directory
                 removedList.ToList().ForEach(sp => auditService.PutIgnore(
-                    context: context,
-                    code: AuditCode.Ignore_ServicePrincipalDeleted,
-                    objectId: sp.Id,
+                    descriptor: new AuditDescriptor
+                    {
+                        CorrelationId = context.CorrelationId,
+                        ObjectId = sp.Id,
+                        AppId = sp.AppId,
+                        DisplayName = sp.DisplayName,
+                    },
+                    code: AuditCode.Deleted,
                     attributeName: "AdditionalData",
                     existingAttributeValue: "@removed"));
                 logger.LogInformation($"\tTrimmed {removedList.Count} ServicePrincipals.");

--- a/src/Automation/CSE.Automation/Interfaces/IAuditService.cs
+++ b/src/Automation/CSE.Automation/Interfaces/IAuditService.cs
@@ -13,12 +13,12 @@ namespace CSE.Automation.Interfaces
 {
     internal interface IAuditService
     {
-        Task PutFail(ActivityContext context, AuditCode code, string objectId, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null);
+        Task PutFail(AuditDescriptor descriptor, AuditCode code, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null);
 
-        Task PutPass(ActivityContext context, AuditCode code, string objectId, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null);
+        Task PutPass(AuditDescriptor descriptor, AuditCode code, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null);
 
-        Task PutIgnore(ActivityContext context, AuditCode code, string objectId, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null);
+        Task PutIgnore(AuditDescriptor descriptor, AuditCode code, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null);
 
-        Task PutChange(ActivityContext context, AuditCode code, string objectId, string attributeName, string existingAttributeValue, string updatedAttributeValue, string message = null, DateTimeOffset? auditTime = null);
+        Task PutChange(AuditDescriptor descriptor, AuditCode code, string attributeName, string existingAttributeValue, string updatedAttributeValue, string message = null, DateTimeOffset? auditTime = null);
     }
 }

--- a/src/Automation/CSE.Automation/Model/ActivityHistory.cs
+++ b/src/Automation/CSE.Automation/Model/ActivityHistory.cs
@@ -14,12 +14,12 @@ namespace CSE.Automation.Model
     internal class ActivityHistory
     {
         /// <summary>
-        /// Gets or sets unique Id of the document
+        /// Gets or sets unique ObjectId of the document
         /// </summary>
         public string Id { get; set; }
 
         /// <summary>
-        /// Gets or sets the correlation Id of the activity
+        /// Gets or sets the correlation ObjectId of the activity
         /// </summary>
         public string CorrelationId { get; set; }
 

--- a/src/Automation/CSE.Automation/Model/AuditActionType.cs
+++ b/src/Automation/CSE.Automation/Model/AuditActionType.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CSE.Automation.Model
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum AuditActionType
+    {
+        /// <summary>
+        /// PASS audit action
+        /// </summary>
+        Pass,
+
+        /// <summary>
+        /// FAIL audit action
+        /// </summary>
+        Fail,
+
+        /// <summary>
+        /// CHANGE audit action
+        /// </summary>
+        Change,
+
+        /// <summary>
+        /// IGNORE audit action
+        /// </summary>
+        Ignore,
+    }
+}

--- a/src/Automation/CSE.Automation/Model/AuditCode.cs
+++ b/src/Automation/CSE.Automation/Model/AuditCode.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.ComponentModel;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CSE.Automation.Model
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    internal enum AuditCode
+    {
+        /// <summary>
+        /// Code for a ServicePrincipal that passed all audit checks
+        /// </summary>
+        [Description("ServicePrincipal passed audit checks.")]
+        Pass = 0,
+
+        /// <summary>
+        /// Code for a ServicePrincipal that was ignored for being already deleted from AAD.
+        /// </summary>
+        [Description("ServicePrincipal ignored - already deleted.")]
+        Deleted = 1,
+
+        /// <summary>
+        /// Code for a ServicePrincipal that was updated in AAD.
+        /// </summary>
+        [Description("ServicePrincipal updated in AAD.")]
+        Updated = 100,
+
+        /// <summary>
+        /// Code for an attribute validation error
+        /// </summary>
+        [Description("Attribute validation failure.")]
+        AttributeValidation = -1,
+
+        /// <summary>
+        /// Code for a ServicePrincipal missing Owner values in the extension field (Notes).
+        /// </summary>
+        [Description("ServicePrincipal is missing Owners in extention field (Notes).")]
+        MissingOwners = -2,
+
+        /// <summary>
+        /// Code when AAD fails to update.
+        /// </summary>
+        [Description("Failed to update ServicePrincipal field: {0}.")]
+        AADUpdate = -3,
+    }
+}

--- a/src/Automation/CSE.Automation/Model/AuditDescriptor.cs
+++ b/src/Automation/CSE.Automation/Model/AuditDescriptor.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace CSE.Automation.Model
+{
+    internal class AuditDescriptor
+    {
+        public string CorrelationId { get; set; }
+        public string ObjectId { get; set; }
+        public string DisplayName { get; set; }
+        public string AppId { get; set; }
+    }
+}

--- a/src/Automation/CSE.Automation/Model/AuditEntry.cs
+++ b/src/Automation/CSE.Automation/Model/AuditEntry.cs
@@ -1,91 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using FluentValidation;
-using FluentValidation.Results;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
 
 namespace CSE.Automation.Model
 {
-    [JsonConverter(typeof(StringEnumConverter))]
-    public enum AuditActionType
-    {
-        /// <summary>
-        /// PASS audit action
-        /// </summary>
-        Pass,
-
-        /// <summary>
-        /// FAIL audit action
-        /// </summary>
-        Fail,
-
-        /// <summary>
-        /// CHANGE audit action
-        /// </summary>
-        Change,
-
-        /// <summary>
-        /// IGNORE audit action
-        /// </summary>
-        Ignore,
-    }
-
-    // Make sure this serializes as an int
-    internal enum AuditCode
-    {
-        /// <summary>
-        /// Code for a ServicePrincipal that passed all audit checks
-        /// </summary>
-        [Description("ServicePrincipal passed audit checks.")]
-        Pass_ServicePrincipal = 0,
-
-        /// <summary>
-        /// Code for a ServicePrincipal that was ignored for being already deleted from AAD.
-        /// </summary>
-        [Description("ServicePrincipal ignored - already deleted.")]
-        Ignore_ServicePrincipalDeleted = 1,
-
-        /// <summary>
-        /// Code for a ServicePrincipal that was updated in AAD.
-        /// </summary>
-        [Description("ServicePrincipal updated in AAD.")]
-        Change_ServicePrincipalUpdated = 100,
-
-        /// <summary>
-        /// Code for an attribute validation error
-        /// </summary>
-        [Description("Attribute validation failure.")]
-        Fail_AttributeValidation = -1,
-
-        /// <summary>
-        /// Code for a ServicePrincipal missing Owner values in the extension field (Notes).
-        /// </summary>
-        [Description("ServicePrincipal is missing Owners in extention field (Notes).")]
-        Fail_MissingOwners = -2,
-
-        /// <summary>
-        /// Code when AAD fails to update.
-        /// </summary>
-        [Description("Failed to update ServicePrincipal field: {0}.")]
-        Fail_AADUpdate = -3,
-    }
-
-    public class AuditEntry
+    internal class AuditEntry
     {
         public string Id { get; set; }
-        public string CorrelationId { get; set; }
 
-        public string ObjectId { get; set; }
+        public AuditDescriptor Descriptor { get; set; }
 
         public AuditActionType Type { get; set; }
 
-        public int Code { get; set; }
+        public AuditCode Code { get; set; }
 
         public string Reason { get; set; }
 

--- a/src/Automation/CSE.Automation/Model/ServicePrincipalComparer.cs
+++ b/src/Automation/CSE.Automation/Model/ServicePrincipalComparer.cs
@@ -13,7 +13,7 @@ namespace CSE.Automation.Model
         /// Use default comparision logic when determining ServicePrincipal equality.
         ///
         /// First, GetHashCode will be called for an initial equality check.  Since the default implementation
-        /// uses the hashcode of the Id, it is determining equality if the Ids of the objects match (case insensitive)
+        /// uses the hashcode of the ObjectId, it is determining equality if the Ids of the objects match (case insensitive)
         /// </summary>
         public class DefaultComparer : IEqualityComparer<ServicePrincipal>
         {

--- a/src/Automation/CSE.Automation/Model/ServicePrincipalUpdateCommand.cs
+++ b/src/Automation/CSE.Automation/Model/ServicePrincipalUpdateCommand.cs
@@ -26,7 +26,9 @@ namespace CSE.Automation.Model
     internal class ServicePrincipalUpdateCommand
     {
         public string CorrelationId { get; set; }
-        public string Id { get; set; }
+        public string ObjectId { get; set; }
+        public string AppId { get; set; }
+        public string DisplayName { get; set; }
         public (string Current, string Changed) Notes { get; set; }
         public ServicePrincipalUpdateAction Action { get; set; }
     }

--- a/src/Automation/CSE.Automation/Model/Validators/AuditEntryValidator.cs
+++ b/src/Automation/CSE.Automation/Model/Validators/AuditEntryValidator.cs
@@ -3,16 +3,19 @@
 
 using System;
 using CSE.Automation.Interfaces;
-using CSE.Automation.Model;
 using FluentValidation;
 
-namespace CSE.Automation.Validators
+namespace CSE.Automation.Model.Validators
 {
-    public class AuditEntryValidator : AbstractValidator<AuditEntry>, IModelValidator<AuditEntry>
+    internal class AuditEntryValidator : AbstractValidator<AuditEntry>, IModelValidator<AuditEntry>
     {
         public AuditEntryValidator()
         {
-            RuleFor(x => x.CorrelationId).NotNull().NotEmpty();
+            RuleFor(x => x.Descriptor).NotNull().DependentRules(() =>
+            {
+                RuleFor(x => x.Descriptor.ObjectId).Cascade(CascadeMode.Stop).NotNull().NotEmpty();
+                RuleFor(x => x.Descriptor.CorrelationId).Cascade(CascadeMode.Stop).NotNull().NotEmpty();
+            });
             RuleFor(x => x.Type).NotEmpty();
             RuleFor(x => x.Reason).NotEmpty();
             RuleFor(x => x.Timestamp).NotEmpty().NotEqual(DateTimeOffset.MinValue);

--- a/src/Automation/CSE.Automation/Model/Validators/CommonValidations.cs
+++ b/src/Automation/CSE.Automation/Model/Validators/CommonValidations.cs
@@ -1,17 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using CSE.Automation.Graph;
 using FluentValidation;
-using FluentValidation.Validators;
-using Microsoft.Graph;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 
-namespace CSE.Automation.Validators
+namespace CSE.Automation.Model.Validators
 {
     /*
     class AADServicePrincipalNameValidator : PropertyValidator

--- a/src/Automation/CSE.Automation/Model/Validators/EmailListValidator.cs
+++ b/src/Automation/CSE.Automation/Model/Validators/EmailListValidator.cs
@@ -1,17 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using CSE.Automation.Graph;
-using FluentValidation;
-using FluentValidation.Validators;
-using Microsoft.Graph;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
+using FluentValidation.Validators;
 
-namespace CSE.Automation.Validators
+namespace CSE.Automation.Model.Validators
 {
     internal class EmailListValidator : PropertyValidator
     {

--- a/src/Automation/CSE.Automation/Model/Validators/GraphModelValidator.cs
+++ b/src/Automation/CSE.Automation/Model/Validators/GraphModelValidator.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using CSE.Automation.Interfaces;
-using CSE.Automation.Model;
-using FluentValidation;
 using System;
 using System.Net.Mail;
 using System.Text.Json;
+using CSE.Automation.Interfaces;
+using FluentValidation;
 
-namespace CSE.Automation.Validators
+namespace CSE.Automation.Model.Validators
 {
     public class GraphModelValidator : AbstractValidator<GraphModel>, IModelValidator<GraphModel>
     {

--- a/src/Automation/CSE.Automation/Model/Validators/ModelValidatorFactory.cs
+++ b/src/Automation/CSE.Automation/Model/Validators/ModelValidatorFactory.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using CSE.Automation.Interfaces;
 using System;
 using System.Collections.Generic;
-using FluentValidation;
-using FluentValidation.Results;
+using CSE.Automation.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace CSE.Automation.Model
+namespace CSE.Automation.Model.Validators
 {
     internal class ModelValidatorFactory : IModelValidatorFactory
     {

--- a/src/Automation/CSE.Automation/Model/Validators/ServicePrincipalModelValidator.cs
+++ b/src/Automation/CSE.Automation/Model/Validators/ServicePrincipalModelValidator.cs
@@ -1,17 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using CSE.Automation.Graph;
-using CSE.Automation.Interfaces;
-using CSE.Automation.Model;
-using FluentValidation;
-using FluentValidation.Results;
-using Microsoft.Extensions.Logging;
-using Microsoft.Graph;
 using System.Linq;
-using System.Runtime.CompilerServices;
+using CSE.Automation.Interfaces;
+using FluentValidation;
+using Microsoft.Graph;
 
-namespace CSE.Automation.Validators
+namespace CSE.Automation.Model.Validators
 {
     internal class ServicePrincipalModelValidator : AbstractValidator<ServicePrincipalModel>, IModelValidator<ServicePrincipalModel>
     {

--- a/src/Automation/CSE.Automation/Services/ActivityService.cs
+++ b/src/Automation/CSE.Automation/Services/ActivityService.cs
@@ -37,9 +37,9 @@ namespace CSE.Automation.Services
         }
 
         /// <summary>
-        /// Given a document Id, return an instance of the ActivityHistory document.
+        /// Given a document ObjectId, return an instance of the ActivityHistory document.
         /// </summary>
-        /// <param name="id">Unique Id of the document.</param>
+        /// <param name="id">Unique ObjectId of the document.</param>
         /// <returns>An instance of <see cref="ActivityHistory"/> document or null.</returns>
         public async Task<ActivityHistory> Get(string id)
         {
@@ -55,7 +55,7 @@ namespace CSE.Automation.Services
         /// Create an instance of an ActivityHistory model
         /// </summary>
         /// <param name="name">Name of the activity</param>
-        /// <param name="correlationId">Correlation Id of the activity</param>
+        /// <param name="correlationId">Correlation ObjectId of the activity</param>
         /// <param name="withTracking">True if the activity is tracked in ActivityHistory</param>
         /// <returns>A new instance of <see cref="ActivityHistory"/>.</returns>
         public ActivityContext CreateContext(string name, string correlationId = null, bool withTracking = false)

--- a/src/Automation/CSE.Automation/Services/AuditService.cs
+++ b/src/Automation/CSE.Automation/Services/AuditService.cs
@@ -24,17 +24,16 @@ namespace CSE.Automation.Services
             this.logger = logger;
         }
 
-        public async Task PutFail(ActivityContext context, AuditCode code, string objectId, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null)
+        public async Task PutFail(AuditDescriptor descriptor, AuditCode code, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null)
         {
             var formatCulture = CultureInfo.CurrentCulture;
             auditTime ??= DateTimeOffset.Now;
 
             var entry = new AuditEntry
             {
-                CorrelationId = context.CorrelationId,
-                ObjectId = objectId,
+                Descriptor = descriptor,
                 Type = AuditActionType.Fail,
-                Code = (int)code,
+                Code = code,
                 Reason = string.Format(formatCulture, code.Description(), attributeName),
                 Message = message,
                 Timestamp = auditTime ?? DateTimeOffset.Now,
@@ -46,20 +45,19 @@ namespace CSE.Automation.Services
             auditRepository.GenerateId(entry);
             await auditRepository.CreateDocumentAsync(entry).ConfigureAwait(false);
 
-            logger.LogTrace($"Logged Audit {code} for {objectId}");
+            logger.LogTrace($"Logged Audit {code} for {descriptor.ObjectId}");
         }
 
-        public async Task PutPass(ActivityContext context, AuditCode code, string objectId, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null)
+        public async Task PutPass(AuditDescriptor descriptor, AuditCode code, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null)
         {
             var formatCulture = CultureInfo.CurrentCulture;
             auditTime ??= DateTimeOffset.Now;
 
             var entry = new AuditEntry
             {
-                CorrelationId = context.CorrelationId,
-                ObjectId = objectId,
+                Descriptor = descriptor,
                 Type = AuditActionType.Pass,
-                Code = (int)code,
+                Code = code,
                 Reason = string.Format(formatCulture, code.Description(), attributeName),
                 Message = message,
                 Timestamp = auditTime.Value,
@@ -71,20 +69,19 @@ namespace CSE.Automation.Services
             auditRepository.GenerateId(entry);
             await auditRepository.CreateDocumentAsync(entry).ConfigureAwait(false);
 
-            logger.LogTrace($"Logged Audit {code} for {objectId}");
+            logger.LogTrace($"Logged Audit {code} for {descriptor.ObjectId}");
         }
 
-        public async Task PutIgnore(ActivityContext context, AuditCode code, string objectId, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null)
+        public async Task PutIgnore(AuditDescriptor descriptor, AuditCode code, string attributeName, string existingAttributeValue, string message = null, DateTimeOffset? auditTime = null)
         {
             var formatCulture = CultureInfo.CurrentCulture;
             auditTime ??= DateTimeOffset.Now;
 
             var entry = new AuditEntry
             {
-                CorrelationId = context.CorrelationId,
-                ObjectId = objectId,
+                Descriptor = descriptor,
                 Type = AuditActionType.Ignore,
-                Code = (int)code,
+                Code = code,
                 Reason = string.Format(formatCulture, code.Description(), attributeName),
                 Message = message,
                 Timestamp = auditTime.Value,
@@ -96,20 +93,19 @@ namespace CSE.Automation.Services
             auditRepository.GenerateId(entry);
             await auditRepository.CreateDocumentAsync(entry).ConfigureAwait(false);
 
-            logger.LogTrace($"Logged Audit {code} for {objectId}");
+            logger.LogTrace($"Logged Audit {code} for {descriptor.ObjectId}");
         }
 
-        public async Task PutChange(ActivityContext context, AuditCode code, string objectId, string attributeName, string existingAttributeValue, string updatedAttributeValue, string message = null, DateTimeOffset? auditTime = null)
+        public async Task PutChange(AuditDescriptor descriptor, AuditCode code, string attributeName, string existingAttributeValue, string updatedAttributeValue, string message = null, DateTimeOffset? auditTime = null)
         {
             var formatCulture = CultureInfo.CurrentCulture;
             auditTime ??= DateTimeOffset.Now;
 
             var entry = new AuditEntry
             {
-                CorrelationId = context.CorrelationId,
-                ObjectId = objectId,
+                Descriptor = descriptor,
                 Type = AuditActionType.Change,
-                Code = (int)code,
+                Code = code,
                 Reason = string.Format(formatCulture, code.Description(), attributeName),
                 Message = message,
                 Timestamp = auditTime.Value,
@@ -122,7 +118,7 @@ namespace CSE.Automation.Services
             auditRepository.GenerateId(entry);
             await auditRepository.CreateDocumentAsync(entry).ConfigureAwait(false);
 
-            logger.LogTrace($"Logged Audit {code} for {objectId}");
+            logger.LogTrace($"Logged Audit {code} for {descriptor.ObjectId}");
         }
     }
 }

--- a/src/Automation/CSE.Automation/Startup.cs
+++ b/src/Automation/CSE.Automation/Startup.cs
@@ -12,10 +12,9 @@ using CSE.Automation.Graph;
 using CSE.Automation.Interfaces;
 using CSE.Automation.KeyVault;
 using CSE.Automation.Model;
+using CSE.Automation.Model.Validators;
 using CSE.Automation.Processors;
 using CSE.Automation.Services;
-using CSE.Automation.Validators;
-
 using FluentValidation;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
#494, add appid to auditentry
fixed validators for model change
fixed tests for model change
corrected namespace of validators

## Type of PR

- [ ] Documentation changes
- [X] Code changes
- [X] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Customer feedback issues.  Refactored AuditEntry to include AppId and DisplayName of the serviceprincipal (if available).  New fields were bundled into a descriptor on the auditentry.  Changed serialization of AuditEntryCode to a string value.
Fixed some namespace issues (validators).
Fixed test cases to align with code changes.

## Review notes

## Issues Closed or Referenced

- Closes #494 
- Closes #496 
