### PR TITLE
Kick Off Full Seed Request Without HTTP Trigger

### DIFF
--- a/scripts/request-full-seed.ps1
+++ b/scripts/request-full-seed.ps1
@@ -121,5 +121,6 @@ $encodedMessage =[Convert]::ToBase64String($Bytes)
 # the auth and queue name parameters seem to be order dependent
 az storage message put --connection-string $StorageConnectionString --queue-name $QueueName --content $encodedMessage 
 
-Write-Host "Message Sent - Queue: $($QueueName), CorrelationId: $($correlationId), DiscoveryMode: $($DiscoveryMode), Source: $($Source)"
+Write-Host "Message Sent - Queue: $($QueueName)"
+Write-Host "Message: $($message)"
 


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Replicate creating an activity document and posting to discover queue using powershell
Post to both Cosmos and Storage Queues is working
JSON values may need tweaking as discover message is being sent to poison queue

## Review notes

## Issues Closed or Referenced

- Closes #539
